### PR TITLE
Update script for Brentwood

### DIFF
--- a/rb-event-data.js
+++ b/rb-event-data.js
@@ -3,7 +3,7 @@ $.noConflict();
 jQuery(document).ready(function () {
   // Configuration
   var eventID;
-  var raffleShortlink = 'gralaska';
+  var raffleShortlink = 'chwbrh-2023';
 
   if (raffleShortlink) {
     // Retrieve Event information
@@ -22,9 +22,17 @@ jQuery(document).ready(function () {
           var drawDate = new Date(event.drawDate).toLocaleDateString('en-US', {
             dateStyle: 'long',
           });
+          var searchParams = new URLSearchParams(window.location.search);
+
+          // Optional Campaign ID
+          var cid = searchParams.get('cid')
+            ? `&cid=${searchParams.get('cid')}`
+            : '';
+
           var checkoutLink =
             'https://checkout.rafflebox.us/goldrush?eventId=' +
             eventID +
+            cid +
             '&locale=en';
 
           // Inject data


### PR DESCRIPTION
- Add Brentwood's shortlink
- Add CID capture
Note: The Brentwood raffle is not active so the checkout link will display the error.

To test you could download the repo, open in vs-code, in the terminal run `npx http-server` and the HTML demo page will be available at `127.0.0.1:8080`
If you click the links they should take you to Brentwood's non-active raffle checkout.
Add a `&cid=blahblahblabh` refresh the page, and now if you click the link you will see the cid is attached to the checkout URL.